### PR TITLE
GitHub has a capital H

### DIFF
--- a/docs/backends/github.rst
+++ b/docs/backends/github.rst
@@ -51,10 +51,10 @@ This ``id`` will be used to check that the user really belongs to the given
 team and discard it if they're not part of it.
 
 
-Github for Enterprises
+GitHub for Enterprises
 ----------------------
 
-Check the docs :ref:`github-enterprise` if planning to use Github
+Check the docs :ref:`github-enterprise` if planning to use GitHub
 Enterprises.
 
 

--- a/docs/backends/github_enterprise.rst
+++ b/docs/backends/github_enterprise.rst
@@ -3,13 +3,13 @@
 GitHub Enterprise
 =================
 
-GitHub Enterprise works similar to regular Github, which is in turn based on Facebook (OAuth).
+GitHub Enterprise works similar to regular GitHub, which is in turn based on Facebook (OAuth).
 
 - Register a new application on your instance of `GitHub Enterprise Developers`_,
   set the callback URL to ``http://example.com/complete/github/`` replacing ``example.com``
   with your domain.
 
-- Set the API URL for your Github Enterprise appliance:
+- Set the API URL for your GitHub Enterprise appliance:
 
       SOCIAL_AUTH_GITHUB_ENTERPRISE_API_URL = 'https://git.example.com/api/v3/'
 

--- a/docs/backends/implementation.rst
+++ b/docs/backends/implementation.rst
@@ -125,8 +125,8 @@ Example code::
 
     from social_core.backends.oauth import BaseOAuth2
 
-    class GithubOAuth2(BaseOAuth2):
-        """Github OAuth authentication backend"""
+    class GitHubOAuth2(BaseOAuth2):
+        """GitHub OAuth authentication backend"""
         name = 'github'
         AUTHORIZATION_URL = 'https://github.com/login/oauth/authorize'
         ACCESS_TOKEN_URL = 'https://github.com/login/oauth/access_token'
@@ -137,7 +137,7 @@ Example code::
         ]
 
         def get_user_details(self, response):
-            """Return user details from Github account"""
+            """Return user details from GitHub account"""
             return {'username': response.get('login'),
                     'email': response.get('email') or '',
                     'first_name': response.get('name')}

--- a/docs/backends/shopify.rst
+++ b/docs/backends/shopify.rst
@@ -3,7 +3,7 @@ Shopify
 
 Shopify uses OAuth 2 for authentication.
 
-To use this backend, you must install the package ``shopify`` from the `Github
+To use this backend, you must install the package ``shopify`` from the `GitHub
 project`_. Currently supports v2+
 
 - Register a new application at `Shopify Partners`_, and
@@ -26,4 +26,4 @@ project`_. Currently supports v2+
 
 .. _Shopify Partners: http://www.shopify.com/partners
 .. _Shopify API: http://api.shopify.com/authentication.html#scopes
-.. _Github project: https://github.com/Shopify/shopify_python_api
+.. _GitHub project: https://github.com/Shopify/shopify_python_api

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -50,7 +50,7 @@ or extend current one):
     * Flickr_ OAuth1
     * Foursquare_ OAuth2
     * `Google App Engine`_ Auth
-    * Github_ OAuth2
+    * GitHub_ OAuth2
     * Google_ OAuth1, OAuth2 and OpenId
     * Instagram_ OAuth2
     * Kakao_ OAuth2
@@ -134,7 +134,7 @@ section.
 .. _Flickr: http://www.flickr.com
 .. _Foursquare: https://foursquare.com
 .. _Google App Engine: https://developers.google.com/appengine/
-.. _Github: https://github.com
+.. _GitHub: https://github.com
 .. _Google: http://google.com
 .. _Instagram: https://instagram.com
 .. _Kakao: https://kakao.com

--- a/site/index.html
+++ b/site/index.html
@@ -59,7 +59,7 @@
             Ported from <a href="https://github.com/omab/django-social-auth">django-social-auth</a>, the application
             brings plenty of authentication providers, many from popular services like <a href="docs/backends/google.html">Google</a>,
             <a href="docs/backends/facebook.html">Facebook</a>, <a href="docs/backends/twitter.html">Twitter</a> and
-            <a href="docs/backends/github.html">Github</a>. The <a href="docs/backends/implementation.html">backends API</a>
+            <a href="docs/backends/github.html">GitHub</a>. The <a href="docs/backends/implementation.html">backends API</a>
             have some implementation details on how to implement your own backends.
           </p>
           <p><a class="btn" href="docs/backends/index.html">View details &raquo;</a></p>
@@ -82,7 +82,7 @@
         <div class="span6">
           <h2>Development and Contact</h2>
           <p>
-            The code is available on <a href="https://github.com/omab/python-social-auth">Github</a>, report any
+            The code is available on <a href="https://github.com/omab/python-social-auth">GitHub</a>, report any
             <a href="https://github.com/omab/python-social-auth/issues">issue</a> if you find any. Pull requests are
             always welcome. There's a <a href="https://groups.google.com/forum/?fromgroups#!forum/python-social-auth">mailing list</a>
             and IRC channel <code>#python-social-auth</code> on Freenode network.


### PR DESCRIPTION
In all of GitHub's branding, the "H" in GitHub is capitalized. We should respect GitHub's branding, and use a capital H when referring to it in the documentation.

Note that the codebase already uses `Github` in several class names, and this pull request doesn't change that. It might be a good idea to switch those over in the future, as well.