### PR TITLE
Fix Stripe Documentation

### DIFF
--- a/docs/backends/stripe.rst
+++ b/docs/backends/stripe.rst
@@ -20,9 +20,9 @@ Stripe uses OAuth2 for its authorization service. To setup Stripe backend:
 
     SOCIAL_AUTH_STRIPE_SCOPE = ['read_only']
 
-- Add the needed backend to ``SOCIAL_AUTH_AUTHENTICATION_BACKENDS``::
+- Add the needed backend to ``AUTHENTICATION_BACKENDS``::
 
-    SOCIAL_AUTH_AUTHENTICATION_BACKENDS = (
+    AUTHENTICATION_BACKENDS = (
         ...
         'social_core.backends.stripe.StripeOAuth2',
         ...


### PR DESCRIPTION
Use the correct Setting name for auth backends.

Fixes python-social-auth/social-core#38