### PR TITLE
config setting missing SOCIAL_AUTH_-prefix

### DIFF
--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -172,7 +172,7 @@ version, etc).
 You can send extra parameters on auth process by defining settings per backend,
 example to request Facebook to show Mobile authorization page, define::
 
-      FACEBOOK_AUTH_EXTRA_ARGUMENTS = {'display': 'touch'}
+      SOCIAL_AUTH_FACEBOOK_AUTH_EXTRA_ARGUMENTS = {'display': 'touch'}
 
 For other providers, just define settings in the form::
 

--- a/docs/use_cases.rst
+++ b/docs/use_cases.rst
@@ -29,7 +29,7 @@ In such cases, add it to ``FIELDS_STORED_IN_SESSION``.
 
 In your settings::
 
-    FIELDS_STORED_IN_SESSION = ['key']
+    SOCIAL_AUTH_FIELDS_STORED_IN_SESSION = ['key']
 
 In template::
 

--- a/docs/use_cases.rst
+++ b/docs/use_cases.rst
@@ -25,7 +25,7 @@ In some cases, you might need to send data over the URL, and retrieve it while
 processing the after-effect. For example, for conditionally executing code in
 custom pipelines.
 
-In such cases, add it to ``FIELDS_STORED_IN_SESSION``.
+In such cases, add it to ``SOCIAL_AUTH_FIELDS_STORED_IN_SESSION``.
 
 In your settings::
 


### PR DESCRIPTION
As per description in the subsequent paragraph, this setting seems to be missing the omnipresent `SOCIAL_AUTH`-prefix to its name.