### PR TITLE
Update used Facebook API version: 2.8 -> 2.9

### DIFF
--- a/docs/backends/facebook.rst
+++ b/docs/backends/facebook.rst
@@ -36,10 +36,10 @@ If you define a redirect URL in Facebook setup page, be sure to not define
 http://127.0.0.1:8000 or http://localhost:8000 because it won't work when
 testing. Instead I define http://myapp.com and setup a mapping on ``/etc/hosts``.
 
-Currently the backend uses Facebook API version `2.8`, this value can
+Currently the backend uses Facebook API version `2.9`, this value can
 be overridden by the following setting if needed::
 
-    SOCIAL_AUTH_FACEBOOK_API_VERSION = '2.9'
+    SOCIAL_AUTH_FACEBOOK_API_VERSION = '2.10'
 
 
 Canvas Application


### PR DESCRIPTION
This updates the documentation to match the default version actually used in the code ([source link](https://github.com/python-social-auth/social-core/blob/1.4.0/social_core/backends/facebook.py#L17)).