### PR TITLE
Fixes documention for SOCIAL_AUTH_SAML_SUPPORT_CONTACT

### DIFF
--- a/docs/backends/saml.rst
+++ b/docs/backends/saml.rst
@@ -57,9 +57,12 @@ At a minimum, you must add the following to your project's settings:
   ``givenName`` and ``emailAddress``, describing the name and email of a
   technical contact responsible for your app. Example::
 
-      {"givenName": "Tech Gal", "emailAddress": "technical@example.com"}
+      SOCIAL_AUTH_SAML_TECHNICAL_CONTACT = {
+          "givenName": "Tech Gal", 
+          "emailAddress": "technical@example.com"
+      }
 
-- ``SOCIAL_AUTH_SAML_TECHNICAL_CONTACT``: A dictionary with two values,
+- ``SOCIAL_AUTH_SAML_SUPPORT_CONTACT``: A dictionary with two values,
   ``givenName`` and ``emailAddress``, describing the name and email of a
   support contact for your app. Example::
 

--- a/docs/backends/saml.rst
+++ b/docs/backends/saml.rst
@@ -57,7 +57,7 @@ At a minimum, you must add the following to your project's settings:
   ``givenName`` and ``emailAddress``, describing the name and email of a
   technical contact responsible for your app. Example::
 
-      SOCIAL_AUTH_SAML_TECHNICAL_CONTACT = {
+      {
           "givenName": "Tech Gal", 
           "emailAddress": "technical@example.com"
       }
@@ -66,7 +66,7 @@ At a minimum, you must add the following to your project's settings:
   ``givenName`` and ``emailAddress``, describing the name and email of a
   support contact for your app. Example::
 
-      SOCIAL_AUTH_SAML_SUPPORT_CONTACT = {
+      {
           "givenName": "Support Guy",
           "emailAddress": "support@example.com",
       }


### PR DESCRIPTION
There were two `SOCIAL_AUTH_SAML_TECHNICAL_CONTACT` entries. Also normalizes `SOCIAL_AUTH_SAML_TECHNICAL_CONTACT` and `SOCIAL_AUTH_SAML_SUPPORT_CONTACT` to match the rest of examples in the document.