### PR TITLE
Update the order of associate_by_email in the Django docs.

### DIFF
--- a/docs/configuration/django.rst
+++ b/docs/configuration/django.rst
@@ -190,11 +190,11 @@ Usage example::
         'social_core.pipeline.social_auth.social_uid',
         'social_core.pipeline.social_auth.social_user',
         'social_core.pipeline.user.get_username',
+        'social_core.pipeline.social_auth.associate_by_email',
         'social_core.pipeline.user.create_user',
         'social_core.pipeline.social_auth.associate_user',
         'social_core.pipeline.social_auth.load_extra_data',
         'social_core.pipeline.user.user_details',
-        'social_core.pipeline.social_auth.associate_by_email',
     )
 
 


### PR DESCRIPTION
Fixes #39.