### PR TITLE
Spell fix in settings variable.

### DIFF
--- a/docs/pipeline.rst
+++ b/docs/pipeline.rst
@@ -155,7 +155,7 @@ In order to override the disconnection pipeline, just define the setting::
     )
 
 Backend specific disconnection pipelines can also be defined with a setting such as
-``SOCIAL_AUTH_TIWTTER_DISCONNECT_PIPELINE``.
+``SOCIAL_AUTH_TWITTER_DISCONNECT_PIPELINE``.
 
 
 Partial Pipeline


### PR DESCRIPTION
Fixed the spelling of the setting variable in disconnection pipeline example.