### PR TITLE
Update pipeline docs with partial_token for email vaildation

### DIFF
--- a/docs/pipeline.rst
+++ b/docs/pipeline.rst
@@ -229,19 +229,21 @@ contains three fields:
     Flag marking if the email was verified or not.
 
 You should use the code in this instance to build the link for email
-validation which should go to ``/complete/email?verification_code=<code here>``. If you are using
+validation which should go to ``/complete/email?verification_code=<code here>&partial_token=<token here>``. If you are using
 Django, you can do it with::
 
     from django.core.urlresolvers import reverse
     url = strategy.build_absolute_uri(
         reverse('social:complete', args=(strategy.backend_name,))
-    ) + '?verification_code=' + code.code
+    ) + '?verification_code=' + code.code + '&partial_token=' + partial_token
+    
+    
 
 On Flask::
 
     from flask import url_for
     url = url_for('social.complete', backend=strategy.backend_name,
-                  _external=True) + '?verification_code=' + code
+                  _external=True) + '?verification_code=' + code.code + '&partial_token=' + partial_token
 
 This pipeline can be used globally with any backend if this setting is
 defined::


### PR DESCRIPTION
This adds a missing parameter to the email validation link, which resumes the partial pipeline flow. The `partial_token` parameter should be included to avoid depending on a session to store the last partial pipeline token.

This is related to https://github.com/python-social-auth/social-core/issues/130 and adds the missing part back to the docs.