### PR TITLE
Fixes #46 - Document Patreon OAuth2 backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added documentation about enabling PostgreSQL JSONB field type
 - Added Eventbrite OAuth2 backend documentation
 - Added note about `SOCIAL_AUTH_CLEAN_USERNAME_FUNCTION` option
+- Added Patreon OAuth2 backend documentation
 
 ### Changed
 - Update partial-pipeline docs with the new storage solution details.

--- a/docs/backends/index.rst
+++ b/docs/backends/index.rst
@@ -116,6 +116,7 @@ Social backends
    openstreetmap
    orbi
    orcid
+   patreon
    persona
    pinterest
    pixelpin

--- a/docs/backends/patreon.rst
+++ b/docs/backends/patreon.rst
@@ -1,0 +1,17 @@
+Patreon
+=======
+
+Patreon supports OAuth 2.0
+
+1. Register a new application at `Patreon Developer Portal`_.
+2. Use the ``social.backends.patreon.PatreonOAuth2``, either by adding it to
+   your ``SOCIAL_AUTH_AUTHENTICATION_BACKENDS`` or instantiating it directly.
+3. Fill in the the ``Client ID`` and ``Client Secret``::
+
+    SOCIAL_AUTH_PATREON_KEY = '<your client ID>'
+    SOCIAL_AUTH_PATREON_SECRET = '<your client secret>'
+
+4. Checkout the `Patreon API Docs`_ for more information.
+
+.. _Patreon Developer Portal: https://www.patreon.com/portal/registration/register-clients
+.. _Patreon API Docs: https://docs.patreon.com/


### PR DESCRIPTION
- Adds documentation about using Patreon OAuth2 backend
- Adds documentation to list of documented backends
- Updates changelog

Verification: Built and viewed docs locally.