### PR TITLE
correct name references to OpenID

### DIFF
--- a/docs/backends/aol.rst
+++ b/docs/backends/aol.rst
@@ -1,7 +1,7 @@
 AOL
 ===
 
-AOL OpenId doesn't require major settings beside being defined on
+AOL OpenID doesn't require major settings beside being defined on
 ``AUTHENTICATION_BACKENDS```::
 
     SOCIAL_AUTH_AUTHENTICATION_BACKENDS = (

--- a/docs/backends/belgium_eid.rst
+++ b/docs/backends/belgium_eid.rst
@@ -1,7 +1,7 @@
 Belgium EID
 ===========
 
-Belgium EID OpenId doesn't require major settings beside being defined on
+Belgium EID OpenID doesn't require major settings beside being defined on
 ``AUTHENTICATION_BACKENDS```::
 
     SOCIAL_AUTH_AUTHENTICATION_BACKENDS = (

--- a/docs/backends/fedora.rst
+++ b/docs/backends/fedora.rst
@@ -1,7 +1,7 @@
 Fedora
 ======
 
-Fedora OpenId doesn't require major settings beside being defined on
+Fedora OpenID doesn't require major settings beside being defined on
 ``AUTHENTICATION_BACKENDS```::
 
     SOCIAL_AUTH_AUTHENTICATION_BACKENDS = (

--- a/docs/backends/google.rst
+++ b/docs/backends/google.rst
@@ -161,10 +161,10 @@ auth process.
     </script>
 
 
-Google OpenId
+Google OpenID
 -------------
 
-Google OpenId works straightforward, no settings are needed. Domains or emails
+Google OpenID works straightforward, no settings are needed. Domains or emails
 whitelists can be applied too, check the whitelists_ settings for details.
 
 

--- a/docs/backends/implementation.rst
+++ b/docs/backends/implementation.rst
@@ -213,18 +213,18 @@ Example code::
             }
 
 
-OpenId
+OpenID
 ------
 
-OpenId is fair simpler that OAuth since it's used for authentication rather
+OpenID is far simpler that OAuth since it's used for authentication rather
 than authorization (regardless it's used for authorization too).
 
 A single attribute is usually needed, the authentication URL endpoint.
 
 ``URL = ''``
-    OpenId endpoint where to redirect the user.
+    OpenID endpoint where to redirect the user.
 
-Sometimes the URL is user dependant, like in myOpenId_ where the URL is
+Sometimes the URL is user dependant, like in myOpenID_ where the URL is
 ``https://<user handler>.myopenid.com``. For those cases where the user must
 input it's handle (or full URL). The backend must override the ``openid_url()``
 method to retrieve it and return a full URL to where the user will be
@@ -302,4 +302,4 @@ Example code::
 
 
 .. _Twitter Docs: https://dev.twitter.com/docs/auth/implementing-sign-twitter
-.. _myOpenId: https://www.myopenid.com/
+.. _myOpenID: https://www.myopenid.com/

--- a/docs/backends/index.rst
+++ b/docs/backends/index.rst
@@ -31,7 +31,7 @@ Non-social backends
    email
    username
 
-Base OAuth and OpenId classes
+Base OAuth and OpenID classes
 *****************************
 
 .. toctree::

--- a/docs/backends/launchpad.rst
+++ b/docs/backends/launchpad.rst
@@ -1,7 +1,7 @@
 Launchpad
 =========
 
-`Ubuntu Launchpad <https://launchpad.net/>`_ OpenId doesn't require
+`Ubuntu Launchpad <https://launchpad.net/>`_ OpenID doesn't require
 major settings beside being defined on ``AUTHENTICATION_BACKENDS```::
 
     SOCIAL_AUTH_AUTHENTICATION_BACKENDS = (

--- a/docs/backends/livejournal.rst
+++ b/docs/backends/livejournal.rst
@@ -1,7 +1,7 @@
 LiveJournal
 ===========
 
-LiveJournal provides OpenId, it doesn't require any major settings in order to
+LiveJournal provides OpenID, it doesn't require any major settings in order to
 work, beside being defined on ``AUTHENTICATION_BACKENDS```::
 
     SOCIAL_AUTH_AUTHENTICATION_BACKENDS = (
@@ -10,7 +10,7 @@ work, beside being defined on ``AUTHENTICATION_BACKENDS```::
         ...
     )
 
-LiveJournal OpenId is provided by URLs in the form ``http://<username>.livejournal.com``,
+LiveJournal OpenID is provided by URLs in the form ``http://<username>.livejournal.com``,
 this application retrieves the ``username`` from the data in the current
 request by checking a parameter named ``openid_lj_user`` which can be sent by
 ``POST`` or ``GET``.

--- a/docs/backends/openid.rst
+++ b/docs/backends/openid.rst
@@ -1,11 +1,11 @@
-OpenId
+OpenID
 ======
 
-OpenId_ support is simpler to implement than OAuth_. Google and Yahoo
+OpenID_ support is simpler to implement than OAuth_. Google and Yahoo
 providers are supported by default, others are supported by POST method
 providing endpoint URL.
 
-OpenId_ backends can store extra data in ``UserSocialAuth.extra_data`` field
+OpenID_ backends can store extra data in ``UserSocialAuth.extra_data`` field
 by defining a set of values names to retrieve from any of the used schemas,
 AttributeExchange and SimpleRegistration. As their keywords differ we need
 two settings.
@@ -31,7 +31,7 @@ any data.
 Username
 --------
 
-The OpenId_ backend will check for a ``username`` key in the values returned by
+The OpenID_ backend will check for a ``username`` key in the values returned by
 the server, but default to ``first-name`` + ``last-name`` if that key is
 missing. It's possible to indicate the username key in the values If the
 username is under a different key with a setting, but backends should have
@@ -40,7 +40,7 @@ defined a default value. For example::
     SOCIAL_AUTH_FEDORA_USERNAME_KEY = 'nickname'
 
 This setting indicates that the username should be populated by the
-``nickname`` value in the Fedora OpenId_ provider.
+``nickname`` value in the Fedora OpenID_ provider.
 
-.. _OpenId: http://openid.net/
+.. _OpenID: http://openid.net/
 .. _OAuth: http://oauth.net/

--- a/docs/backends/steam.rst
+++ b/docs/backends/steam.rst
@@ -1,7 +1,7 @@
-Steam OpenId
+Steam OpenID
 ============
 
-Steam OpenId works quite straightforward, but to retrieve some user data (known
+Steam OpenID works quite straightforward, but to retrieve some user data (known
 as ``player`` on Steam API) a Steam API Key is needed.
 
 Configurable settings:

--- a/docs/backends/suse.rst
+++ b/docs/backends/suse.rst
@@ -4,10 +4,10 @@ SUSE
 This section describes how to setup the different services provided by SUSE and openSUSE.
 
 
-openSUSE OpenId
+openSUSE OpenID
 ---------------
 
-openSUSE OpenId works straightforward, not settings are needed. Domains or emails
+openSUSE OpenID works straightforward, not settings are needed. Domains or emails
 whitelists can be applied too, check the whitelists_ settings for details.
 
 .. _whitelists: ../configuration/settings.html#whitelists

--- a/docs/backends/yahoo.rst
+++ b/docs/backends/yahoo.rst
@@ -1,13 +1,13 @@
 Yahoo
 =====
 
-Yahoo supports OpenId and OAuth2 for their auth flow.
+Yahoo supports OpenID and OAuth2 for their auth flow.
 
 
-Yahoo OpenId
+Yahoo OpenID
 ------------
 
-OpenId doesn't require any particular configuration beside enabling the backend
+OpenID doesn't require any particular configuration beside enabling the backend
 in the ``AUTHENTICATION_BACKENDS`` setting::
 
     AUTHENTICATION_BACKENDS = (

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -36,7 +36,7 @@ Keys and secrets
     SOCIAL_AUTH_TWITTER_KEY = 'foobar'
     SOCIAL_AUTH_TWITTER_SECRET = 'bazqux'
 
-OpenId backends don't require keys usually, but some need some API Key to
+OpenID backends don't require keys usually, but some need some API Key to
 call any API on the provider. Check Backends_ sections for details.
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ Welcome to Python Social Auth's documentation!
 
 Python Social Auth aims to be an easy to setup social authentication and
 authorization mechanism for Python projects supporting protocols like OAuth (1
-and 2), OpenId and others.
+and 2), OpenID and others.
 
 The initial codebase is derived from django-social-auth_ with the idea of
 generalizing the process to suit the different frameworks around, providing

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -45,7 +45,7 @@ needed. There are some ``extras`` defined to install the corresponding
 dependencies since they require to build extensions that, unless used,
 are undesired.
 
-* OpenIdConnect_ support requires the use of the ``openidconnect`` extra.
+* OpenIDConnect_ support requires the use of the ``openidconnect`` extra.
 * SAML_ support requires the use of ``saml`` extra.
 
 There's also the ``all`` extra that will install all the extra options.
@@ -76,15 +76,15 @@ Using the ``extras`` options
 ----------------------------
 
 To enable any of the ``extras`` options to bring the dependencines for
-OpenIdConnect_, or SAML_, or both::
+OpenIDConnect_, or SAML_, or both::
 
   $ pip install "social-auth-core[openidconnect]"
   $ pip install "social-auth-core[saml]"
   $ pip install "social-auth-core[all]"
 
 
-.. _OpenId: http://openid.net/
-.. _OpenIdConnect: http://openid.net/connect/
+.. _OpenID: http://openid.net/
+.. _OpenIDConnect: http://openid.net/connect/
 .. _OAuth: http://oauth.net/
 .. _SAML: https://www.onelogin.com/saml
 .. _pypi: http://pypi.python.org/pypi/python-social-auth/

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -3,7 +3,7 @@ Introduction
 
 Python Social Auth aims to be an easy to setup social authentication and
 authorization mechanism for Python projects supporting protocols like OAuth_ (1
-and 2), OpenId_ and others.
+and 2), OpenID_ and others.
 
 
 Features
@@ -52,20 +52,20 @@ or extend current one):
     * Foursquare_ OAuth2
     * `Google App Engine`_ Auth
     * GitHub_ OAuth2
-    * Google_ OAuth1, OAuth2 and OpenId
+    * Google_ OAuth1, OAuth2 and OpenID
     * Instagram_ OAuth2
     * Kakao_ OAuth2
     * Linkedin_ OAuth1
     * Live_ OAuth2
-    * Livejournal_ OpenId
+    * Livejournal_ OpenID
     * Mailru_ OAuth2
     * MineID_ OAuth2
     * Mixcloud_ OAuth2
     * `Mozilla Persona`_
     * NaszaKlasa_ OAuth2
-    * `NGPVAN ActionID`_ OpenId
+    * `NGPVAN ActionID`_ OpenID
     * Odnoklassniki_ OAuth2 and Application Auth
-    * OpenId_
+    * OpenID_
     * Podio_ OAuth2
     * Pinterest_ OAuth2
     * Rdio_ OAuth1 and OAuth2
@@ -76,7 +76,7 @@ or extend current one):
     * Spotify_ OAuth2
     * ThisIsMyJam_ OAuth1
     * Stackoverflow_ OAuth2
-    * Steam_ OpenId
+    * Steam_ OpenID
     * Stocktwits_ OAuth2
     * Stripe_ OAuth2
     * Tripit_ OAuth1
@@ -90,9 +90,9 @@ or extend current one):
     * Weibo_ OAuth2
     * Wunderlist_ OAuth2
     * Xing_ OAuth1
-    * Yahoo_ OpenId and OAuth1
+    * Yahoo_ OpenID and OAuth1
     * Yammer_ OAuth2
-    * Yandex_ OAuth1, OAuth2 and OpenId
+    * Yandex_ OAuth1, OAuth2 and OpenID
 
 
 User data
@@ -116,7 +116,7 @@ mechanism in ways that suits your project. Check `Authentication Pipeline`_
 section.
 
 
-.. _OpenId: http://openid.net/
+.. _OpenID: http://openid.net/
 .. _OAuth: http://oauth.net/
 .. _myOpenID: https://www.myopenid.com/
 .. _Angel: https://angel.co

--- a/docs/storage.rst
+++ b/docs/storage.rst
@@ -94,7 +94,7 @@ needed methods:
 Nonce
 -----
 
-This is a helper class for OpenId mechanism, it stores a one-use number,
+This is a helper class for OpenID mechanism, it stores a one-use number,
 shouldn't be used by the project since it's for internal use only.
 
 When implementing this model, it must inherits from NonceMixin_, and override
@@ -109,7 +109,7 @@ the needed method::
 Association
 -----------
 
-Another OpenId helper class, it stores basic data to keep the OpenId
+Another OpenID helper class, it stores basic data to keep the OpenID
 association. Like Nonce_ this is for internal use only.
 
 When implementing this model, it must inherits from AssociationMixin_, and

--- a/docs/tests.rst
+++ b/docs/tests.rst
@@ -36,7 +36,7 @@ You can use tox_ to test compatibility against all supported Python versions:
 Pending
 -------
 
-At the moment only OAuth1, OAuth2 and OpenId backends are being tested, and
+At the moment only OAuth1, OAuth2 and OpenID backends are being tested, and
 just login and partial pipeline features are covered by the test. There's still
 a lot to work on, like:
 


### PR DESCRIPTION
Correct references to the OpenID ecosystem to have a capitalized 'D' at the end if not a code (module or variable) reference to be consistent with the spec's official name.