### PR TITLE
fix:apple link added on backend index

### DIFF
--- a/docs/backends/index.rst
+++ b/docs/backends/index.rst
@@ -52,6 +52,7 @@ Social backends
    aol
    apple
    appsfuel
+   apple
    arcgis
    azuread
    battlenet


### PR DESCRIPTION
Apple backend doc on backend index page