### PR TITLE
Add maintainers sections

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,7 @@ Contents:
    :maxdepth: 2
 
    intro
+   maintainers
    installing
    configuration/index
    pipeline

--- a/docs/maintainers.rst
+++ b/docs/maintainers.rst
@@ -1,0 +1,13 @@
+Maintainers
+===========
+
+This project is maintained by:
+
+* `Matías Aguirre`_
+* `Michal Čihař`_
+
+The project is open for mainteners, take a look to `issue #539`_  for details.
+
+.. _Matías Aguirre: https://github.com/omab
+.. _Michal Čihař: https://github.com/nijel
+.. _issue #539: https://github.com/python-social-auth/social-core/issues/539


### PR DESCRIPTION
This PR introduces a `maintainers` section to the doc in order to list the team in charge of this task.