### PR TITLE
Add (unformatted) osso docs

### DIFF
--- a/docs/backends/index.rst
+++ b/docs/backends/index.rst
@@ -121,6 +121,7 @@ Social backends
    openstreetmap
    orbi
    orcid
+   osso
    patreon
    persona
    pinterest

--- a/docs/backends/osso.rst
+++ b/docs/backends/osso.rst
@@ -34,6 +34,8 @@ the user to the correct IDP. If you don't include one of these parameters, and i
 will display a hosted login page. Here's an example login form with ``email``:
 
 
+.. code-block:: html+django
+
       <form action="{% url 'social:begin' 'osso' %}" method="post" class="login-form">
           <label>Email</label>
           <input type="email" name="email" />

--- a/docs/backends/osso.rst
+++ b/docs/backends/osso.rst
@@ -17,7 +17,7 @@ To enable Osso as a backend:
     )
 
 - Create or update an OAuth Client in your Osso instance, adding a redirect URI to your allow
-  ``http://example.com/complete/osso/`` replacing ``http://example.com`` with your Osso instance URL. 
+  ``http://example.com/complete/osso/`` replacing ``http://example.com`` with your application's domain. 
   Grab the ``Client ID`` and ``Client Secret`` to use in your application.
 
 - Add these values of ``Client ID`` and ``Client Secret`` from Osso in your project settings file.

--- a/docs/backends/osso.rst
+++ b/docs/backends/osso.rst
@@ -34,9 +34,9 @@ the user to the correct IDP. If you don't include one of these parameters, and i
 will display a hosted login page. Here's an example login form with ``email``:
 
 
-    <form action="{% url 'social:begin' 'osso' %}" method="post" class="login-form">
-        <label>Email</label>
-        <input type="email" name="email" />
-        {% csrf_token %}
-        <button type="submit">Sign in with SSO</button>
-    </div>  
+      <form action="{% url 'social:begin' 'osso' %}" method="post" class="login-form">
+          <label>Email</label>
+          <input type="email" name="email" />
+          {% csrf_token %}
+          <button type="submit">Sign in with SSO</button>
+      </form>  

--- a/docs/backends/osso.rst
+++ b/docs/backends/osso.rst
@@ -1,0 +1,42 @@
+Osso - Open Source SAML SSO
+================================
+
+Osso is an open source service that handles SAML tenant onboarding, documentation and authentication.
+
+Your application can then consume normalized user profile resources as part of an OAuth 2.0 authorization code grant flow.
+
+Learn more about Osso at https://ossoapp.com or continue below to start consuming your Osso instance from your application via Python Social Auth.
+
+To enable Osso as a backend:
+
+- On your project settings, add Osso on your ``AUTHENTICATION_BACKENDS``::
+
+    AUTHENTICATION_BACKENDS = (
+        ...
+        'social_core.backends.osso.OssoOAuth2',
+    )
+
+- Create or update an OAuth Client in your Osso instance, adding a redirect URI to your allow
+  ``http://example.com/complete/osso/`` replacing ``http://example.com`` with your Osso instance URL. 
+  Grab the ``Client ID`` and ``Client Secret`` to use in your application.
+
+- Add these values of ``Client ID`` and ``Client Secret`` from Osso in your project settings file.
+
+The ``Client ID`` should be added on ``SOCIAL_AUTH_OSSO_KEY`` and the ``Client Secret`` should be
+added on ``SOCIAL_AUTH_OSSO_SECRET``. You also need to add your Osso instance base URL as ``SOCIAL_AUTH_OSSO_BASE_URL``::
+
+      SOCIAL_AUTH_OSSO_KEY = os.getenv('SOCIAL_AUTH_OSSO_KEY')
+      SOCIAL_AUTH_OSSO_SECRET = os.getenv('SOCIAL_AUTH_OSSO_SECRET')
+      SOCIAL_AUTH_OSSO_BASE_URL = 'https://demo.ossoapp.com'
+      
+When constructing your sign in flow, Osso supports passing an ``email`` or ``domain`` parameter in order to route 
+the user to the correct IDP. If you don't include one of these parameters, and instead implement a button, Osso 
+will display a hosted login page. Here's an example login form with ``email``:
+
+
+    <form action="{% url 'social:begin' 'osso' %}" method="post" class="login-form">
+        <label>Email</label>
+        <input type="email" name="email" />
+        {% csrf_token %}
+        <button type="submit">Sign in with SSO</button>
+    </div>  


### PR DESCRIPTION
Adds documentation for Osso per https://github.com/python-social-auth/social-core/pull/564

I'm having a lot of trouble figuring out how to lint/ autoformat these restructured text files. 

I see the Pep8 note in contributing doc, I guess that's been renamed to `pycodestyle`?

If someone could point me in the right direct for how to format from CLI or VSCode (im using venv) that would be super helpful. I'd be happy to update the contributing docs