### PR TITLE
docs: update Shopify backend documentation

### DIFF
--- a/docs/backends/shopify.rst
+++ b/docs/backends/shopify.rst
@@ -32,7 +32,7 @@ To use this backend, you must:
                                    'write_customers',
                                    'read_products']
 
-- Set your desired Shopify API version in your settings. The backend default of `2019-04` is no longer supported by the Shopify python library::
+- If you'd like to, you can set your desired Shopify API version in your settings::
       
       SOCIAL_AUTH_SHOPIFY_API_VERSION = '2020-10'
       

--- a/docs/backends/shopify.rst
+++ b/docs/backends/shopify.rst
@@ -3,15 +3,23 @@ Shopify
 
 Shopify uses OAuth 2 for authentication.
 
-To use this backend, you must install the package ``shopify`` from the `GitHub
-project`_. Currently supports v2+
+To use this backend, you must:
 
-- Register a new application at `Shopify Partners`_, and
+- Install the `Shopify python library`_::
+  
+    pip install --upgrade ShopifyAPI
 
-- Set the Auth Type to OAuth2 in the application settings
-
-- Set the Application URL to http://[your domain]/login/shopify/
-
+- Register a new application at `Shopify Partners`_
+- Set the Application URL to `https://[your domain]/login/shopify/`
+- Set the callback URL to `https://[your domain]/complete/shopify/`
+- Add the backendm to your AUTHENTICATION_BACKENDS config::
+  
+    AUTHENTICATION_BACKENDS = (
+        ...,
+        'social_core.backends.shopify.ShopifyOAuth2',
+        ...,
+    )
+    
 - fill ``API Key`` and ``Shared Secret`` values in your django settings::
 
       SOCIAL_AUTH_SHOPIFY_KEY   = ''
@@ -24,6 +32,10 @@ project`_. Currently supports v2+
                                    'write_customers',
                                    'read_products']
 
+- Set your desired Shopify API version in your settings. The backend default of `2019-04` is no longer supported by the Shopify python library::
+      
+      SOCIAL_AUTH_SHOPIFY_API_VERSION = '2020-10'
+      
 `ShopifyAPI 5.0.0`_ introduced a non backward compatible change in order to
 support Shopify API versioning. The backend will default to value `2019-04` but
 it's possible to override the default with the following setting::
@@ -32,5 +44,5 @@ it's possible to override the default with the following setting::
 
 .. _Shopify Partners: http://www.shopify.com/partners
 .. _Shopify API: http://api.shopify.com/authentication.html#scopes
-.. _GitHub project: https://github.com/Shopify/shopify_python_api
+.. _Shopify python library: https://github.com/Shopify/shopify_python_api
 .. _ShopifyAPI 5.0.0: https://github.com/Shopify/shopify_python_api#-breaking-change-notice-for-version-500-

--- a/docs/backends/shopify.rst
+++ b/docs/backends/shopify.rst
@@ -10,9 +10,9 @@ To use this backend, you must:
     pip install --upgrade ShopifyAPI
 
 - Register a new application at `Shopify Partners`_
-- Set the Application URL to `https://[your domain]/login/shopify/`
-- Set the callback URL to `https://[your domain]/complete/shopify/`
-- Add the backendm to your AUTHENTICATION_BACKENDS config::
+- Configure your Shopify app to use the application URL of `https://[your domain]/login/shopify/`
+- Configure your Shopify app to use the callback URL of `https://[your domain]/complete/shopify/`
+- If you're using Django, add the backend to your AUTHENTICATION_BACKENDS configuration::
   
     AUTHENTICATION_BACKENDS = (
         ...,


### PR DESCRIPTION
The existing documentation is missing a few steps to set up and use the Shopify backend. This PR fills in those gaps. 