### PR TITLE
Update Django database docs

### DIFF
--- a/docs/configuration/django.rst
+++ b/docs/configuration/django.rst
@@ -48,15 +48,15 @@ Also ensure to define the MongoEngine_ storage setting::
 Database
 --------
 
+When using PostgreSQL, it's recommended to use the built-in `JSONB`
+field to store the extracted `extra_data`. To enable it define the setting::
+
+  SOCIAL_AUTH_JSONFIELD_ENABLED = True
+
 (For Django 1.7 and higher) you need to sync the database to create needed
 models once you added ``social_django`` to your installed apps::
 
     ./manage.py migrate
-
-When using PostgreSQL, it's recommended to use the built-in `JSONB`
-field to store the extracted `extra_data`. To enable it define the setting::
-
-  SOCIAL_AUTH_POSTGRES_JSONFIELD = True
 
 
 Authentication backends

--- a/docs/configuration/django.rst
+++ b/docs/configuration/django.rst
@@ -49,7 +49,7 @@ Database
 --------
 
 When using PostgreSQL, it's recommended to use the built-in `JSONB`
-field to store the extracted `extra_data`. To enable it define the setting::
+field to store the extracted ``extra_data``. To enable it define the setting::
 
   SOCIAL_AUTH_JSONFIELD_ENABLED = True
 


### PR DESCRIPTION
Help people not to shoot themselves in the foot by first highlighting the JSONFIELD
setting and only then pointing to migrate, if you first migrate it's much harder to fix 
this setting later.

Also fixed the JSONFIELD setting to the latest recommended since Django 3.1