### PR TITLE
deps: Pin readthedocs environment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,5 @@
+version: 2
+
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx==4.2.0
+sphinx_rtd_theme==1.0.0
+readthedocs-sphinx-search==0.1.1


### PR DESCRIPTION
This should avoid sudden build failures.

See https://github.com/readthedocs/readthedocs.org/issues/8616