### PR TITLE
Fix typo

### DIFF
--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -17,7 +17,7 @@ than just the ``ValueError`` usually raised.
     Authentication was canceled by the user.
 
 ``AuthUnknownError``
-    An unknown error stoped the authentication process.
+    An unknown error stopped the authentication process.
 
 ``AuthTokenError``
     Unauthorized or access token error, it was invalid, impossible to


### PR DESCRIPTION
There was a minor typo in the exceptions documentation. "Stopped" was spelled "stoped". This patch fixes it.