### PR TITLE
Update django.rst

### DIFF
--- a/docs/configuration/django.rst
+++ b/docs/configuration/django.rst
@@ -103,6 +103,14 @@ In case you need a custom namespace, this setting is also needed::
     SOCIAL_AUTH_URL_NAMESPACE = 'social'
 
 
+Requiring POST only login
+-------------------------
+
+By default login url ``social:begin`` uses ``GET`` request if you would like to require ``POST`` only (for example to comply with SOC audits) logging in then please use::
+
+    SOCIAL_AUTH_REQUIRE_POST = True
+
+
 Templates
 ---------
 


### PR DESCRIPTION
To reflect Django configuration changes related to https://github.com/python-social-auth/social-app-django/pull/493 this PR adds notes about using `SOCIAL_AUTH_REQUIRE_POST` configuration.