### PR TITLE
Fix Deprecation Note

### DIFF
--- a/docs/configuration/django.rst
+++ b/docs/configuration/django.rst
@@ -82,7 +82,7 @@ or Django won't pick them when trying to authenticate the user.
 Don't miss ``django.contrib.auth.backends.ModelBackend`` if using ``django.contrib.auth``
 application or users won't be able to login by username / password method.
 
-Also, note that ``social_core.backends.google.GoogleOpenId`` has been deprecated.
+Also, note that ``social_core.backends.google.GoogleOAuth`` has been deprecated.
 
 For more documentation about setting backends to specific social applications, please see the :doc:`/backends/index`.
 


### PR DESCRIPTION
I doesn't look to me like `social_core.backends.google.GoogleOpenId` exists and openid connect (AFAIK) is still supported by google.

I think this should be `social_core.backends.google.GoogleOAuth`