### PR TITLE
fixed attribute 'YahooOpenId' not found

### DIFF
--- a/docs/backends/yahoo.rst
+++ b/docs/backends/yahoo.rst
@@ -12,7 +12,7 @@ in the ``AUTHENTICATION_BACKENDS`` setting::
 
     AUTHENTICATION_BACKENDS = (
         ...
-        'social_core.backends.yahoo.YahooOpenId',
+        'social_core.backends.yahoo.YahooOAuth2',
         ...
     )
 


### PR DESCRIPTION
Fixed module 'social_core.backends.yahoo' has no attribute 'YahooOpenId'

**Problem**
![image](https://github.com/python-social-auth/social-docs/assets/24577149/6aff0853-0f7b-465f-9145-c84266ceeb25)

Instead of :

```
AUTHENTICATION_BACKENDS = (
    ...
    'social_core.backends.yahoo.YahooOpenId',
    ...
)
```

we should have 

```
AUTHENTICATION_BACKENDS = (
    ...
    'social_core.backends.yahoo.YahooOAuth2',
    ...
)
```